### PR TITLE
Improvements to making it more fault tolerant

### DIFF
--- a/generate-ca.sh
+++ b/generate-ca.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/bin/bash -e
 
 touch certindex.txt
-mkdir certs/
-mkdir private/
+mkdir -p certs/
+mkdir -p private/
 
 openssl req -new -x509 -extensions v3_ca -keyout \
 private/cakey.crt -out cacert.crt -days 3650 -config ./openssl.cnf

--- a/generate-ca.sh
+++ b/generate-ca.sh
@@ -4,5 +4,5 @@ touch certindex.txt
 mkdir -p certs/
 mkdir -p private/
 
-openssl req -new -x509 -extensions v3_ca -keyout \
-private/cakey.crt -out cacert.crt -days 3650 -config ./openssl.cnf
+openssl req -new -x509 -extensions v3_ca -nodes -keyout private/cakey.crt \
+	-out cacert.crt -days 3650 -config ./openssl.cnf

--- a/generate-ca.sh
+++ b/generate-ca.sh
@@ -6,4 +6,3 @@ mkdir -p private/
 
 openssl req -new -x509 -extensions v3_ca -keyout \
 private/cakey.crt -out cacert.crt -days 3650 -config ./openssl.cnf
-echo "subjectAltName                          = @alt_names" >> ./openssl.cnf

--- a/generate-crt.sh
+++ b/generate-crt.sh
@@ -1,6 +1,11 @@
-#!/bin/bash
+#!/bin/bash -e
 
 export CERT_HOST=$1
+if [[ -z $CERT_HOST ]] ; then
+	echo "Usage: $0 CERT_HOST"
+	exit 1
+fi
+
 mkdir $CERT_HOST
 echo "[alt_names]" >> ./openssl.cnf
 echo "DNS.1 = $CERT_HOST" >> ./openssl.cnf

--- a/generate-crt.sh
+++ b/generate-crt.sh
@@ -7,8 +7,6 @@ if [[ -z $CERT_HOST ]] ; then
 fi
 
 mkdir $CERT_HOST
-echo "[alt_names]" >> ./openssl.cnf
-echo "DNS.1 = $CERT_HOST" >> ./openssl.cnf
 cat <<EOF | openssl req -new -nodes -out ./$CERT_HOST/$CERT_HOST.crt.req\
   -keyout ./$CERT_HOST/$CERT_HOST.key -config ./openssl.cnf
 
@@ -21,4 +19,3 @@ $CERT_HOST
 EOF
 
 openssl ca -out ./$CERT_HOST/$CERT_HOST.crt -config ./openssl.cnf -infiles ./$CERT_HOST/$CERT_HOST.crt.req
-sed -i '76,77d' ./openssl.cnf

--- a/openssl.cnf
+++ b/openssl.cnf
@@ -72,3 +72,7 @@ basicConstraints                        = CA:FALSE
 subjectKeyIdentifier                    = hash
 keyUsage                                = nonRepudiation, digitalSignature, keyEncipherment
 extendedKeyUsage                        = serverAuth, clientAuth, codeSigning, emailProtection
+subjectAltName                          = @alt_names
+
+[ alt_names ]
+DNS.1                                   = $ENV::CERT_HOST


### PR DESCRIPTION
a093fb2 Do not require a passphrase on the CA
5721d31 Do not modify openssl.cnf
4818087 Run bash in strict mode

I held back on moving the CA to its own directory and cleaning up the gitignore so git status is a bit cleaner, but let me know what you think about that.