### PR TITLE
Export CERT_HOST to avoid an openssl error

### DIFF
--- a/generate-ca.sh
+++ b/generate-ca.sh
@@ -4,5 +4,6 @@ touch certindex.txt
 mkdir -p certs/
 mkdir -p private/
 
+export CERT_HOST=""
 openssl req -new -x509 -extensions v3_ca -nodes -keyout private/cakey.crt \
 	-out cacert.crt -days 3650 -config ./openssl.cnf


### PR DESCRIPTION
error on line 78 of ./openssl.cnf
140546353997712:error:0E065068:configuration file routines:STR_COPY:variable has no value:conf_def.c:584:line 78

Fixes #4 